### PR TITLE
CHA-1099: update openapi (use UUID + plural endpoints)

### DIFF
--- a/api/generated/generated_postman_collection.json
+++ b/api/generated/generated_postman_collection.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "e5652b4a-3465-4766-843f-b68c7f380aa8"
+    "postman_id": "e3cbfd5a-aaa1-48f2-96a5-f0efe41c9052"
   },
   "item": [
     {
-      "id": "5006b097-979e-49bc-9ca8-c93340656a8d",
+      "id": "3af99f03-1409-4eed-b424-2f8f6add1a4d",
       "name": "UI Extension",
       "description": {
         "content": "Manipulate UI Extensions",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "a60bd8e3-9f94-4955-93c4-91b34712d547",
+          "id": "565c0995-2573-47dc-a4bd-c6761effa4a2",
           "name": "List extensions",
           "request": {
             "name": "List extensions",
@@ -25,7 +25,7 @@
                 "api",
                 "rest",
                 "v1",
-                "ui-extension"
+                "ui-extensions"
               ],
               "host": [
                 "{{baseUrl}}"
@@ -47,12 +47,12 @@
             {
               "listen": "test",
               "script": {
-                "id": "5d6b908b-6554-47ed-ba7a-a0aa9c3bf138",
+                "id": "1117a9e3-5535-450b-abf7-563c497e0502",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/api/rest/v1/ui-extension - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
-                  "// Validate if response has JSON Body \npm.test(\"[GET]::/api/rest/v1/ui-extension - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"type\":\"array\",\"description\":\"Represents a list of extensions\",\"items\":{\"anyOf\":[{\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_header\",\"enum\":[\"edit_product_header\",\"edit_root_product_model_header\",\"edit_sub_product_model_header\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_button\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_tab\",\"enum\":[\"edit_product_tab\",\"edit_category_tab\",\"product_grid_quick_action\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/rest/v1/ui-extension - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Validate if response header has matching content-type\npm.test(\"[GET]::/api/rest/v1/ui-extensions - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[GET]::/api/rest/v1/ui-extensions - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"type\":\"array\",\"description\":\"Represents a list of extensions\",\"items\":{\"anyOf\":[{\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_header\",\"enum\":[\"edit_product_header\",\"edit_root_product_model_header\",\"edit_sub_product_model_header\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_button\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_tab\",\"enum\":[\"edit_product_tab\",\"edit_category_tab\",\"product_grid_quick_action\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/rest/v1/ui-extensions - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -62,7 +62,7 @@
           }
         },
         {
-          "id": "8b48cba0-fce3-4b2b-8413-18dc1df04ba4",
+          "id": "9afc2c9c-1d0b-40a6-b15b-b5f695cf100a",
           "name": "Add an extension",
           "request": {
             "name": "Add an extension",
@@ -75,7 +75,7 @@
                 "api",
                 "rest",
                 "v1",
-                "ui-extension"
+                "ui-extensions"
               ],
               "host": [
                 "{{baseUrl}}"
@@ -110,12 +110,12 @@
             {
               "listen": "test",
               "script": {
-                "id": "c1a32042-ce1b-4eca-83eb-397062fdcf7c",
+                "id": "29a18c56-f66e-49c7-b1c4-5bc8d6df9fab",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate if response header has matching content-type\npm.test(\"[POST]::/api/rest/v1/ui-extension - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
-                  "// Validate if response has JSON Body \npm.test(\"[POST]::/api/rest/v1/ui-extension - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_header\",\"enum\":[\"edit_product_header\",\"edit_root_product_model_header\",\"edit_sub_product_model_header\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_button\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_tab\",\"enum\":[\"edit_product_tab\",\"edit_category_tab\",\"product_grid_quick_action\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/api/rest/v1/ui-extension - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Validate if response header has matching content-type\npm.test(\"[POST]::/api/rest/v1/ui-extensions - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[POST]::/api/rest/v1/ui-extensions - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_header\",\"enum\":[\"edit_product_header\",\"edit_root_product_model_header\",\"edit_sub_product_model_header\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_button\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_tab\",\"enum\":[\"edit_product_tab\",\"edit_category_tab\",\"product_grid_quick_action\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/api/rest/v1/ui-extensions - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -125,7 +125,7 @@
           }
         },
         {
-          "id": "629093e2-0871-4cd6-8584-b04c6e137a7b",
+          "id": "31463f6f-18c0-4866-a27a-b5634635e4cf",
           "name": "Update an extension",
           "request": {
             "name": "Update an extension",
@@ -138,7 +138,7 @@
                 "api",
                 "rest",
                 "v1",
-                "ui-extension",
+                "ui-extensions",
                 ":ui_extension_uuid"
               ],
               "host": [
@@ -185,12 +185,12 @@
             {
               "listen": "test",
               "script": {
-                "id": "3f7b8ad0-50dc-431b-8931-514e99b78d66",
+                "id": "a7944a70-23fd-4465-b912-e4d3715e149a",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate if response header has matching content-type\npm.test(\"[PATCH]::/api/rest/v1/ui-extension/:ui_extension_uuid - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
-                  "// Validate if response has JSON Body \npm.test(\"[PATCH]::/api/rest/v1/ui-extension/:ui_extension_uuid - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-                  "// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_header\",\"enum\":[\"edit_product_header\",\"edit_root_product_model_header\",\"edit_sub_product_model_header\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_button\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_tab\",\"enum\":[\"edit_product_tab\",\"edit_category_tab\",\"product_grid_quick_action\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[PATCH]::/api/rest/v1/ui-extension/:ui_extension_uuid - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                  "// Validate if response header has matching content-type\npm.test(\"[PATCH]::/api/rest/v1/ui-extensions/:ui_extension_uuid - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[PATCH]::/api/rest/v1/ui-extensions/:ui_extension_uuid - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_header\",\"enum\":[\"edit_product_header\",\"edit_root_product_model_header\",\"edit_sub_product_model_header\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_button\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_tab\",\"enum\":[\"edit_product_tab\",\"edit_category_tab\",\"product_grid_quick_action\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[PATCH]::/api/rest/v1/ui-extensions/:ui_extension_uuid - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
                 ]
               }
             }
@@ -200,7 +200,7 @@
           }
         },
         {
-          "id": "cb5f9127-2b4e-4d71-8e7f-63770626d531",
+          "id": "8e57de99-896e-4157-a95e-94c82f036b2d",
           "name": "Delete an extension",
           "request": {
             "name": "Delete an extension",
@@ -213,7 +213,7 @@
                 "api",
                 "rest",
                 "v1",
-                "ui-extension",
+                "ui-extensions",
                 ":ui_extension_uuid"
               ],
               "host": [
@@ -241,10 +241,10 @@
             {
               "listen": "test",
               "script": {
-                "id": "00112d75-f885-4c37-8e4a-9a4afc423482",
+                "id": "a01fa080-70e4-46be-99bb-a82c9899be4f",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate if response has empty Body \npm.test(\"[DELETE]::/api/rest/v1/ui-extension/:ui_extension_uuid - Response has empty Body\", function () {\n    pm.response.to.not.be.withBody;\n});\n"
+                  "// Validate if response has empty Body \npm.test(\"[DELETE]::/api/rest/v1/ui-extensions/:ui_extension_uuid - Response has empty Body\", function () {\n    pm.response.to.not.be.withBody;\n});\n"
                 ]
               }
             }
@@ -271,7 +271,7 @@
     {
       "listen": "prerequest",
       "script": {
-        "id": "a9d93374-14aa-43e9-8cd4-0b1b57310376",
+        "id": "4eb7510a-1e0f-4945-9e58-704212198349",
         "type": "text/javascript",
         "exec": [
           "/*\n For simplicity, we acquire a new token before each API call.\n This is not recommended to do the same in production. \n \n Benefit from the 1 hour validity of the access_token and leverage the refresh_token grant type.\n Explore the official PIM API documentation for details https://api.akeneo.com/documentation/authentication.html\n\n*/\n\nappAccessToken = pm.environment.get(\"app_access_token\")\nif (appAccessToken!==undefined) {\n    pm.environment.set(\"pim_access_token\", appAccessToken)\n    console.log(\"Used the token provided in the \\\"app_access_token\\\" variable instead of authenticating with the PIM.\")\n    return\n}\n\nbase64ClientIdSecret = require('btoa')(pm.environment.get(\"clientId\") + ':' + pm.environment.get(\"secret\"))\n\npm.sendRequest({\n    url: pm.environment.get(\"baseUrl\").replace(/\\/$/, '') + '/api/oauth/v1/token',\n    method: 'POST',\n    header: {\n        'Authorization': 'Basic ' + base64ClientIdSecret,\n        'Content-Type': 'application/json',\n    },\n    body: {\n        mode: 'raw',\n        raw: JSON.stringify(\n            {\n                \"username\" : pm.environment.get(\"username\"),\n                \"password\" : pm.environment.get(\"password\"),\n                \"grant_type\": \"password\"\n            }\n        )\n    }\n}, function (err, res) {\n    if(err !== null ){\n        console.error(\"The following error occured during pre-script execution\");\n        console.error(err);\n        return;\n    }\n    console.warn(\"For simplicity, we acquire a new token before each API call, this is not recommended in production. Benefit from the 1 hour validity of the access_token.\");\n    pm.environment.set(\"pim_access_token\", res.json().access_token);\n});"
@@ -307,7 +307,7 @@
     }
   ],
   "info": {
-    "_postman_id": "e5652b4a-3465-4766-843f-b68c7f380aa8",
+    "_postman_id": "e3cbfd5a-aaa1-48f2-96a5-f0efe41c9052",
     "name": "Akeneo PIM UI Extension",
     "version": {
       "raw": "1.0.0",

--- a/api/generated/generated_postman_collection.json
+++ b/api/generated/generated_postman_collection.json
@@ -1,10 +1,10 @@
 {
   "_": {
-    "postman_id": "7bac4606-639d-436b-a17d-7fcdde733aa3"
+    "postman_id": "e5652b4a-3465-4766-843f-b68c7f380aa8"
   },
   "item": [
     {
-      "id": "af18048a-a974-4ac4-aba8-e1de0662d891",
+      "id": "5006b097-979e-49bc-9ca8-c93340656a8d",
       "name": "UI Extension",
       "description": {
         "content": "Manipulate UI Extensions",
@@ -12,7 +12,7 @@
       },
       "item": [
         {
-          "id": "ba7d2415-5863-4724-b02b-284641d92f56",
+          "id": "a60bd8e3-9f94-4955-93c4-91b34712d547",
           "name": "List extensions",
           "request": {
             "name": "List extensions",
@@ -47,7 +47,7 @@
             {
               "listen": "test",
               "script": {
-                "id": "38f2ce57-3d8d-4dba-9d2e-d22e90893941",
+                "id": "5d6b908b-6554-47ed-ba7a-a0aa9c3bf138",
                 "type": "text/javascript",
                 "exec": [
                   "// Validate if response header has matching content-type\npm.test(\"[GET]::/api/rest/v1/ui-extension - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
@@ -62,10 +62,73 @@
           }
         },
         {
-          "id": "7ce232eb-772d-413a-93f8-e870a9407207",
-          "name": "Upsert an extension",
+          "id": "8b48cba0-fce3-4b2b-8413-18dc1df04ba4",
+          "name": "Add an extension",
           "request": {
-            "name": "Upsert an extension",
+            "name": "Add an extension",
+            "description": {
+              "content": "The `configuration` depends on the `position`. Available positions are `edit_product_tab`, `edit_category_tab` and `edit_product_header`, `edit_root_product_model_header`, `edit_sub_product_model_header`.\nFor now, the only configuration keys are the same for all the position.\n\nThe `type` available are `simple_iframe` and `simple_button`. It depends on the `position` :\n- `simple_iframe` for `edit_product_tab`, `edit_category_tab` and `product_grid_quick_action`\n- `simple_button` for `edit_product_header`, `edit_root_product_model_header` and `edit_sub_product_model_header`\n",
+              "type": "text/plain"
+            },
+            "url": {
+              "path": [
+                "api",
+                "rest",
+                "v1",
+                "ui-extension"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variable": []
+            },
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"code\": \"my_awesome_button_extension\",\n  \"position\": \"edit_product_header\",\n  \"type\": \"simple_button\",\n  \"configuration\": {\n    \"url\": \"https://www.example.com\",\n    \"default_label\": \"My awesome button extension\",\n    \"labels\": {\n      \"en_US\": \"My awesome button extension\",\n      \"fr_FR\": \"Ma super button extension\"\n    }\n  }\n}",
+              "options": {
+                "raw": {
+                  "headerFamily": "json",
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "c1a32042-ce1b-4eca-83eb-397062fdcf7c",
+                "type": "text/javascript",
+                "exec": [
+                  "// Validate if response header has matching content-type\npm.test(\"[POST]::/api/rest/v1/ui-extension - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[POST]::/api/rest/v1/ui-extension - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_header\",\"enum\":[\"edit_product_header\",\"edit_root_product_model_header\",\"edit_sub_product_model_header\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_button\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_tab\",\"enum\":[\"edit_product_tab\",\"edit_category_tab\",\"product_grid_quick_action\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/api/rest/v1/ui-extension - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                ]
+              }
+            }
+          ],
+          "protocolProfileBehavior": {
+            "disableBodyPruning": true
+          }
+        },
+        {
+          "id": "629093e2-0871-4cd6-8584-b04c6e137a7b",
+          "name": "Update an extension",
+          "request": {
+            "name": "Update an extension",
             "description": {
               "content": "The `configuration` depends on the `position`. Available positions are `edit_product_tab`, `edit_category_tab` and `edit_product_header`, `edit_root_product_model_header`, `edit_sub_product_model_header`.\nFor now, the only configuration keys are the same for all the position.\n\nThe `type` available are `simple_iframe` and `simple_button`. It depends on the `position` :\n- `simple_iframe` for `edit_product_tab`, `edit_category_tab` and `product_grid_quick_action`\n- `simple_button` for `edit_product_header`, `edit_root_product_model_header` and `edit_sub_product_model_header`\n",
               "type": "text/plain"
@@ -76,7 +139,7 @@
                 "rest",
                 "v1",
                 "ui-extension",
-                ":ui_extension_code"
+                ":ui_extension_uuid"
               ],
               "host": [
                 "{{baseUrl}}"
@@ -90,8 +153,8 @@
                     "type": "text/plain"
                   },
                   "type": "any",
-                  "value": "my_awesome_button_extension",
-                  "key": "ui_extension_code"
+                  "value": "e175d525-8fbf-4b26-9242-1daccf301f8b",
+                  "key": "ui_extension_uuid"
                 }
               ]
             },
@@ -99,12 +162,16 @@
               {
                 "key": "Content-Type",
                 "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
               }
             ],
-            "method": "POST",
+            "method": "PATCH",
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"code\": \"my_awesome_button_extension\",\n  \"position\": \"edit_product_header\",\n  \"type\": \"simple_button\",\n  \"configuration\": {\n    \"url\": \"http://www.example.com\",\n    \"default_label\": \"My awesome button extension\",\n    \"labels\": {\n      \"en_US\": \"My awesome button extension\",\n      \"fr_FR\": \"Ma super button extension\"\n    }\n  }\n}",
+              "raw": "{\n  \"code\": \"my_awesome_button_extension\",\n  \"position\": \"edit_product_header\",\n  \"type\": \"simple_button\",\n  \"configuration\": {\n    \"url\": \"https://www.example.com\",\n    \"default_label\": \"My awesome button extension\",\n    \"labels\": {\n      \"en_US\": \"My awesome button extension\",\n      \"fr_FR\": \"Ma super button extension\"\n    }\n  }\n}",
               "options": {
                 "raw": {
                   "headerFamily": "json",
@@ -114,13 +181,26 @@
             }
           },
           "response": [],
-          "event": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "3f7b8ad0-50dc-431b-8931-514e99b78d66",
+                "type": "text/javascript",
+                "exec": [
+                  "// Validate if response header has matching content-type\npm.test(\"[PATCH]::/api/rest/v1/ui-extension/:ui_extension_uuid - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+                  "// Validate if response has JSON Body \npm.test(\"[PATCH]::/api/rest/v1/ui-extension/:ui_extension_uuid - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+                  "// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_header\",\"enum\":[\"edit_product_header\",\"edit_root_product_model_header\",\"edit_sub_product_model_header\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_button\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"code\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"edit_product_tab\",\"enum\":[\"edit_product_tab\",\"edit_category_tab\",\"product_grid_quick_action\"]},\"type\":{\"type\":\"string\",\"default\":\"simple_iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[PATCH]::/api/rest/v1/ui-extension/:ui_extension_uuid - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+                ]
+              }
+            }
+          ],
           "protocolProfileBehavior": {
             "disableBodyPruning": true
           }
         },
         {
-          "id": "35bb5588-0d46-44db-9bfa-434c6bf367f8",
+          "id": "cb5f9127-2b4e-4d71-8e7f-63770626d531",
           "name": "Delete an extension",
           "request": {
             "name": "Delete an extension",
@@ -134,7 +214,7 @@
                 "rest",
                 "v1",
                 "ui-extension",
-                ":ui_extension_code"
+                ":ui_extension_uuid"
               ],
               "host": [
                 "{{baseUrl}}"
@@ -148,8 +228,8 @@
                     "type": "text/plain"
                   },
                   "type": "any",
-                  "value": "my_awesome_button_extension",
-                  "key": "ui_extension_code"
+                  "value": "e175d525-8fbf-4b26-9242-1daccf301f8b",
+                  "key": "ui_extension_uuid"
                 }
               ]
             },
@@ -161,10 +241,10 @@
             {
               "listen": "test",
               "script": {
-                "id": "f8fdc722-9287-4ed2-ae74-68d8c9bba3f2",
+                "id": "00112d75-f885-4c37-8e4a-9a4afc423482",
                 "type": "text/javascript",
                 "exec": [
-                  "// Validate if response has empty Body \npm.test(\"[DELETE]::/api/rest/v1/ui-extension/:ui_extension_code - Response has empty Body\", function () {\n    pm.response.to.not.be.withBody;\n});\n"
+                  "// Validate if response has empty Body \npm.test(\"[DELETE]::/api/rest/v1/ui-extension/:ui_extension_uuid - Response has empty Body\", function () {\n    pm.response.to.not.be.withBody;\n});\n"
                 ]
               }
             }
@@ -191,7 +271,7 @@
     {
       "listen": "prerequest",
       "script": {
-        "id": "154f697c-d5f7-417f-96a1-f3fdfc3aec5e",
+        "id": "a9d93374-14aa-43e9-8cd4-0b1b57310376",
         "type": "text/javascript",
         "exec": [
           "/*\n For simplicity, we acquire a new token before each API call.\n This is not recommended to do the same in production. \n \n Benefit from the 1 hour validity of the access_token and leverage the refresh_token grant type.\n Explore the official PIM API documentation for details https://api.akeneo.com/documentation/authentication.html\n\n*/\n\nappAccessToken = pm.environment.get(\"app_access_token\")\nif (appAccessToken!==undefined) {\n    pm.environment.set(\"pim_access_token\", appAccessToken)\n    console.log(\"Used the token provided in the \\\"app_access_token\\\" variable instead of authenticating with the PIM.\")\n    return\n}\n\nbase64ClientIdSecret = require('btoa')(pm.environment.get(\"clientId\") + ':' + pm.environment.get(\"secret\"))\n\npm.sendRequest({\n    url: pm.environment.get(\"baseUrl\").replace(/\\/$/, '') + '/api/oauth/v1/token',\n    method: 'POST',\n    header: {\n        'Authorization': 'Basic ' + base64ClientIdSecret,\n        'Content-Type': 'application/json',\n    },\n    body: {\n        mode: 'raw',\n        raw: JSON.stringify(\n            {\n                \"username\" : pm.environment.get(\"username\"),\n                \"password\" : pm.environment.get(\"password\"),\n                \"grant_type\": \"password\"\n            }\n        )\n    }\n}, function (err, res) {\n    if(err !== null ){\n        console.error(\"The following error occured during pre-script execution\");\n        console.error(err);\n        return;\n    }\n    console.warn(\"For simplicity, we acquire a new token before each API call, this is not recommended in production. Benefit from the 1 hour validity of the access_token.\");\n    pm.environment.set(\"pim_access_token\", res.json().access_token);\n});"
@@ -227,7 +307,7 @@
     }
   ],
   "info": {
-    "_postman_id": "7bac4606-639d-436b-a17d-7fcdde733aa3",
+    "_postman_id": "e5652b4a-3465-4766-843f-b68c7f380aa8",
     "name": "Akeneo PIM UI Extension",
     "version": {
       "raw": "1.0.0",

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8,7 +8,7 @@ tags:
   - name: UI Extension 
     description: Manipulate UI Extensions
 paths:
-  /api/rest/v1/ui-extension:
+  /api/rest/v1/ui-extensions:
     get:
       summary: 'List extensions'
       description: 'List all extensions associated with your token'
@@ -62,7 +62,7 @@ paths:
         '422':
           description: |
             Violation error
-  /api/rest/v1/ui-extension/{ui_extension_uuid}:
+  /api/rest/v1/ui-extensions/{ui_extension_uuid}:
     patch:
       summary: 'Update an extension'
       description: |

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -24,9 +24,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ui_extension_list_response'
-  /api/rest/v1/ui-extension/{ui_extension_code}:
     post:
-      summary: 'Upsert an extension'
+      summary: 'Add an extension'
       description: |
         The `configuration` depends on the `position`. Available positions are `edit_product_tab`, `edit_category_tab` and `edit_product_header`, `edit_root_product_model_header`, `edit_sub_product_model_header`.
         For now, the only configuration keys are the same for all the position.
@@ -34,9 +33,7 @@ paths:
         The `type` available are `simple_iframe` and `simple_button`. It depends on the `position` :
         - `simple_iframe` for `edit_product_tab`, `edit_category_tab` and `product_grid_quick_action`
         - `simple_button` for `edit_product_header`, `edit_root_product_model_header` and `edit_sub_product_model_header`
-      parameters:
-        - $ref: "#/components/parameters/ui_extension_code"
-      operationId: upsert_extension
+      operationId: add_extension
       tags:
         - UI Extension
       requestBody:
@@ -47,15 +44,59 @@ paths:
           application/json:
             schema:
               oneOf:
-                - $ref: "#/components/schemas/ui_extension_simple_button_body"
-                - $ref: "#/components/schemas/ui_extension_simple_iframe_body"
+                - $ref: "#/components/schemas/ui_extension_simple_button_request"
+                - $ref: "#/components/schemas/ui_extension_simple_iframe_request"
       responses:
         '201':
           description: |
             Ui Extension created
-        '204':
+          content:
+            application/json:
+              schema: 
+                oneOf: 
+                  - $ref: "#/components/schemas/ui_extension_simple_button_response"
+                  - $ref: "#/components/schemas/ui_extension_simple_iframe_response"
+        '400':
+          description: |
+            Invalid Json
+        '422':
+          description: |
+            Violation error
+  /api/rest/v1/ui-extension/{ui_extension_uuid}:
+    patch:
+      summary: 'Update an extension'
+      description: |
+        The `configuration` depends on the `position`. Available positions are `edit_product_tab`, `edit_category_tab` and `edit_product_header`, `edit_root_product_model_header`, `edit_sub_product_model_header`.
+        For now, the only configuration keys are the same for all the position.
+
+        The `type` available are `simple_iframe` and `simple_button`. It depends on the `position` :
+        - `simple_iframe` for `edit_product_tab`, `edit_category_tab` and `product_grid_quick_action`
+        - `simple_button` for `edit_product_header`, `edit_root_product_model_header` and `edit_sub_product_model_header`
+      parameters:
+        - $ref: "#/components/parameters/ui_extension_uuid"
+      operationId: update_extension
+      tags:
+        - UI Extension
+      requestBody:
+        description: |
+          whatever
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/ui_extension_simple_button_request"
+                - $ref: "#/components/schemas/ui_extension_simple_iframe_request"
+      responses:
+        '200':
           description: |
             Ui Extension updated
+          content:
+            application/json:
+              schema: 
+                oneOf: 
+                  - $ref: "#/components/schemas/ui_extension_simple_button_response"
+                  - $ref: "#/components/schemas/ui_extension_simple_iframe_response"
         '400':
           description: |
             Invalid Json
@@ -66,14 +107,14 @@ paths:
       summary: 'Delete an extension'
       description: 'Delete an extension'
       parameters:
-        - $ref: "#/components/parameters/ui_extension_code"
+        - $ref: "#/components/parameters/ui_extension_uuid"
       operationId: delete_extension
       tags:
         - UI Extension
       responses:
         '204':
           description: |
-            Deleted successfuly
+            Deleted successfully
         '404':
           description: |
             Extension does not exists
@@ -86,22 +127,22 @@ components:
   links: {}
   callbacks: {}
   parameters: 
-    ui_extension_code:
-      name: ui_extension_code
+    ui_extension_uuid:
+      name: ui_extension_uuid
       in: path
       required: true
       schema:
         type: string
-        example: my_awesome_button_extension
+        example: e175d525-8fbf-4b26-9242-1daccf301f8b
   schemas: 
     ui_extension_list_response:
       type: array
       description: 'Represents a list of extensions'
       items: 
         anyOf: 
-          - $ref: "#/components/schemas/ui_extension_simple_button_body"
-          - $ref: "#/components/schemas/ui_extension_simple_iframe_body"
-    ui_extension_simple_button_body:
+          - $ref: "#/components/schemas/ui_extension_simple_button_request"
+          - $ref: "#/components/schemas/ui_extension_simple_iframe_request"
+    ui_extension_simple_button_request:
       type: object
       properties:
         code:
@@ -132,9 +173,77 @@ components:
                 fr_FR:
                   type: string
                   example: Ma super button extension
-    ui_extension_simple_iframe_body:
+    ui_extension_simple_iframe_request:
       type: object
       properties:
+        code:
+          type: string
+          example: my_awesome_iframe_extension
+        position:
+          type: string
+          default: edit_product_tab
+          enum: [edit_product_tab, edit_category_tab, product_grid_quick_action]
+        type:
+          type: string
+          default: simple_iframe
+        configuration:
+          type: object
+          properties:
+            url:
+              type: string
+              example: https://www.example.com
+            default_label:
+              type: string
+              example: My awesome iFrame extension
+            labels:
+              type: object 
+              properties:
+                en_US:
+                  type: string
+                  example: My awesome iFrame extension
+                fr_FR:
+                  type: string
+                  example: Ma super iFrame extension
+    ui_extension_simple_button_response:
+      type: object
+      properties:
+        uuid:
+          type: string
+          example: f641347d-1768-4e7b-8bb1-e2ff34b05875
+        code:
+          type: string
+          example: my_awesome_button_extension
+        position:
+          type: string
+          default: edit_product_header
+          enum: [edit_product_header, edit_root_product_model_header, edit_sub_product_model_header]
+        type:
+          type: string
+          default: simple_button
+        configuration:
+          type: object
+          properties:
+            url:
+              type: string
+              example: https://www.example.com
+            default_label:
+              type: string
+              example: My awesome button extension
+            labels:
+              type: object 
+              properties:
+                en_US:
+                  type: string
+                  example: My awesome button extension
+                fr_FR:
+                  type: string
+                  example: Ma super button extension
+    ui_extension_simple_iframe_response:
+      type: object
+      properties:
+        uuid:
+          type: string
+          example: 5c8026f9-1617-4529-9623-1d7f8a70a89e
         code:
           type: string
           example: my_awesome_iframe_extension

--- a/api/tooling.dockerfile
+++ b/api/tooling.dockerfile
@@ -7,12 +7,13 @@ ARG DEV_UID=1000
 ARG DEV_GID=1000
 
 # Ensure the node user have the correct uid/gid
-RUN deluser --remove-home node \
-  && addgroup -S node -g ${DEV_GID} \
-  && adduser -S -G node -u ${DEV_UID} node
+RUN apk add --no-cache shadow
+RUN usermod --uid ${DEV_UID} node && \
+    groupmod --gid ${DEV_GID} node
 
 # Let the node modules be installed for our node user, not root
 USER node
+
 RUN mkdir -p "/home/node/.node"
 ENV ENV="/home/node/.profile"
 RUN echo "prefix = /home/node/.node" | tee -a ${HOME}/.npmrc


### PR DESCRIPTION
Modifications on PIM side come soon. 
- Upsert will be divided in two distinct endpoints. 
- To identify, modify, or delete an extension you must use its UUID.
- Endpoints URI will contain `ui-extensions` with a `s`