### PR TITLE
fixProductContextPropagation

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -153,7 +153,7 @@ components:
           example: V1.02.3
         description:
           type: string
-          example: A short human readable description of the extension intent.
+          example: A short human readable description.
         position:
           type: string
           default: pim.product.header
@@ -190,7 +190,7 @@ components:
           example: 20250301250
         description:
           type: string
-          example: A short human readable description of the extension intent.
+          example: A short human readable description.
         position:
           type: string
           default: pim.product.tab
@@ -230,7 +230,7 @@ components:
           example: 2.32
         description:
           type: string
-          example: A short human readable description of the extension intent.
+          example: A short human readable description.
         position:
           type: string
           default: pim.product.header
@@ -273,7 +273,7 @@ components:
           example: 2025-03-02-109
         description:
           type: string
-          example: A short human readable description of the extension intent.
+          example: A short human readable description.
         position:
           type: string
           default: pim.product.tab

--- a/nextjs_iframe/src/app/examples/product-context-propagation/page.tsx
+++ b/nextjs_iframe/src/app/examples/product-context-propagation/page.tsx
@@ -9,7 +9,13 @@ function ContextPropagation() {
     const [scope, setScope] = useState('');
 
     const handlePostMessage = (event: MessageEvent) => {
-        if (event.origin !== "http://localhost:8080") {
+        console.log("enter handle post message");
+
+        // Check if the origin is http://localhost:8080
+        // Check if the origin is a subdomain of https://*.akeneo.com
+        const akeneoPattern = /^https:\/\/[^\/]+\.akeneo\.com$/;
+        if (event.origin !== "http://localhost:8080" && !akeneoPattern.test(event.origin)) {
+            console.log(event);
             console.error("can't accept MessageEvent from this origin due to my configuration");
             return;
         }
@@ -30,10 +36,12 @@ function ContextPropagation() {
     };
 
     React.useEffect(() => {
+        console.log("add event listener on message");
         window.addEventListener('message', handlePostMessage, false);
 
         // cleanup this component
         return () => {
+            console.log("remove event listener on message");
             window.removeEventListener('message', handlePostMessage);
         };
     }, []);


### PR DESCRIPTION
Allow to the example page "https://next-dot-akecld-prd-sdk-aep-sdx.ew.r.appspot.com/examples/product-context-propagation" to receive postMessage events from localhost and akeneo domains.

Fix the open API definition, the description field to not pass our validation, we should provide examples that work out of the box :) (cf screenshot)

![Screenshot from 2025-01-29 09-00-54](https://github.com/user-attachments/assets/ab135218-1752-4f6e-891c-66570b6a54c8)
